### PR TITLE
[Fix] #4 Headeer의 Cities 링크 404 에러 수정

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,7 +13,7 @@ import { useCityStore } from "../stores/useCitystore";
 // ─────── 페이지 목록 ───────
 const pages = [
   { name: "Home", path: "/" },
-  { name: "Cities", path: "/cities" },
+  { name: "Cities", path: "#" },
   { name: "Landmark", path: "/" },
   { name: "About", path: "/" },
 ];


### PR DESCRIPTION

## 🔍 개요 (Overview)
Header의 Cities 링크가 404 에러를 발생시키는 버그를 수정
(예: Closes #4 )


## ✅ 작업 사항 (Work Done)

- [x] Header의 Cities 링크 href를 `#` 로 변경

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
| <img width="792" height="52" alt="image" src="https://github.com/user-attachments/assets/79995452-24a9-4b77-96b9-e2fad70c3a23" /> |   에러 안뜸  |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
