### PR TITLE
[fix] #8 Tour API JSON 파싱 오류

### DIFF
--- a/app/api/tour/route.ts
+++ b/app/api/tour/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   const serviceKey = encodeURIComponent(process.env.TOUR_API_KEY || "");
   // 가장 최신의 정보 : 지난 달(이번 달은 정보 업데이트 전)
   const now = new Date();
-  now.setMonth(now.getMonth() - 1);
+  now.setMonth(now.getMonth() - 2);
   const baseYm =
     now.getFullYear().toString() + String(now.getMonth() + 1).padStart(2, "0");
   // 3개의 시군구를 병렬 fetch


### PR DESCRIPTION
## 🔍 개요 (Overview)
`/api/tour` API 에서 TarRlteTarService1 JSON 파싱 오류 수정
`baseYm=202512`(미래 날짜) → `202511`(유효 데이터)로 변경
(Closes #8 )


## ✅ 작업 사항 (Work Done)
- [X] now.setMonth(now.getMonth() - 2)로 변경 (1개월 전 → 2개월 전)

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
| <img width="755" height="502" alt="image" src="https://github.com/user-attachments/assets/7ec1d7c0-656f-49a6-982b-6b32682025d0" /> | <img width="816" height="829" alt="image" src="https://github.com/user-attachments/assets/20f6839a-f9a6-474a-b0e5-c252d03ae7df" /> |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
